### PR TITLE
Update to version 1.2.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,15 +1,18 @@
-{% set version = "1.1.0" %}
+{% set version = '1.2.0' %}
+
+{% set posix = 'm2-' if win else '' %}
+{% set native = 'm2w64-' if win else '' %}
 
 package:
   name: r-stringr
-  version: {{ version }}
+  version: {{ version|replace("-", "_") }}
 
 source:
   fn: stringr_{{ version }}.tar.gz
   url:
-    - http://cran.r-project.org/src/contrib/stringr_{{ version }}.tar.gz
-    - http://cran.r-project.org/src/contrib/Archive/stringr/stringr_{{ version }}.tar.gz
-  sha256: ccb1f0e0f3e9524786f6cbae705c42eedf3874d0e641564e5e00517d892c5a33
+    - https://cran.r-project.org/src/contrib/stringr_{{ version }}.tar.gz
+    - https://cran.r-project.org/src/contrib/Archive/stringr/stringr_{{ version }}.tar.gz
+  sha256: 61d0b30768bbfd7c0bb89310e2de5b7b457ac504538acbcca50374b46b16129a
 
 build:
   number: 0
@@ -45,3 +48,4 @@ about:
 extra:
   recipe-maintainers:
     - ocefpaf
+    - jdblischak


### PR DESCRIPTION
This PR updates r-stringr from 1.1.0 to 1.2.0. This version includes some new functionality which is required by packages like r-rmarkdown.

@ocefpaf please review and merge when you can